### PR TITLE
Fix admin role route docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -56,7 +56,7 @@
 ```
 
 ### Assign Admin Role
-- **PUT** `/auth/assign-admin?email={email}`
+- **GET** `/auth/assign-admin?email={email}`
 - **Description**: Assigns admin role to a user (admin only)
 - **Headers**: `Authorization: Bearer {token}`
 


### PR DESCRIPTION
## Summary
- update docs to reflect GET `/auth/assign-admin` route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ae88a790832abd58912627ecc3c1